### PR TITLE
Add calls to setMemName to fix SRAM names for VLSI

### DIFF
--- a/src/main/scala/memserdes.scala
+++ b/src/main/scala/memserdes.scala
@@ -232,7 +232,7 @@ class HellaFlowQueue[T <: Data](val entries: Int)(data: => T) extends Module
   do_flow := empty && io.deq.ready
 
   val ram = SeqMem(data, entries)
-  ram.setName("Flow_Queue_Mem")
+  ram.setMemName("Flow_Queue_Mem")
   when (do_enq) { ram.write(enq_ptr, io.enq.bits) }
 
   val ren = io.deq.ready && (atLeastTwo || !io.deq.valid && !empty)

--- a/src/main/scala/memserdes.scala
+++ b/src/main/scala/memserdes.scala
@@ -232,6 +232,7 @@ class HellaFlowQueue[T <: Data](val entries: Int)(data: => T) extends Module
   do_flow := empty && io.deq.ready
 
   val ram = SeqMem(data, entries)
+  ram.setName("Flow_Queue_Mem")
   when (do_enq) { ram.write(enq_ptr, io.enq.bits) }
 
   val ren = io.deq.ready && (atLeastTwo || !io.deq.valid && !empty)


### PR DESCRIPTION
This allows for predictable naming of the internal `Mem`s inside `SeqMem`s and helps with the scriptability of the VLSI flow.

This requires chisel >= ucb-bar/chisel@8f37a8e; all repos needing `setMemName`-related patches will get bumped in rocket-chip.
