### PR TITLE
Chisel 3 Support

### DIFF
--- a/src/main/scala/memserdes.scala
+++ b/src/main/scala/memserdes.scala
@@ -57,7 +57,7 @@ class MemPipeIO(implicit p: Parameters) extends ParameterizedBundle()(p) {
 class MemSerializedIO(w: Int)(implicit p: Parameters) extends ParameterizedBundle()(p) {
   val req = Decoupled(Bits(width = w))
   val resp = Valid(Bits(width = w)).flip
-  //override def cloneType = new MemSerializedIO(w)(p).asInstanceOf[this.type]
+  override def cloneType = new MemSerializedIO(w)(p).asInstanceOf[this.type]
 }
 
 class MemSerdes(w: Int)(implicit p: Parameters) extends MIFModule

--- a/src/main/scala/util.scala
+++ b/src/main/scala/util.scala
@@ -8,7 +8,17 @@ object bigIntPow2 {
 }
 
 class ParameterizedBundle(implicit p: Parameters) extends Bundle {
-  override def cloneType = this.getClass.getConstructors.head.newInstance(p).asInstanceOf[this.type]
+  override def cloneType = {
+    try {
+      this.getClass.getConstructors.head.newInstance(p).asInstanceOf[this.type]
+    } catch {
+      case e: java.lang.IllegalArgumentException =>
+        throwException("Unable to use ParamaterizedBundle.cloneType on " +
+                       this.getClass + ", probably because " + this.getClass +
+                       "() takes more than one argument.  Consider overriding " +
+                       "cloneType() on " + this.getClass, e)
+    }
+  }
 }
 
 class HellaFlowQueue[T <: Data](val entries: Int)(data: => T) extends Module {


### PR DESCRIPTION
I haven't tested this as it stands, I've just applied these two patches on top of 4069e88d849a5fd6e82d238e45e4c97f9a0d2b44 in junctions (marked as stable in rocket-chip).  When I use junctions/master in rocket-chip, I get failures in uncore, and when I also add uncore/master I get other failures.  None of them look related to what I've done here, so I think it's just a different incompatibility.

With the patches applied as mentioned above, this builds with both chisel 2 and 3.