### PR TITLE
Define MIFMasterTagBits as # bits a master can *use* in tag

### DIFF
--- a/src/main/scala/memserdes.scala
+++ b/src/main/scala/memserdes.scala
@@ -8,6 +8,7 @@ import cde.{Parameters, Field}
 case object MIFAddrBits extends Field[Int]
 case object MIFDataBits extends Field[Int]
 case object MIFTagBits extends Field[Int]
+case object MIFMasterTagBits extends Field[Int]
 case object MIFDataBeats extends Field[Int]
 
 trait HasMIFParameters {


### PR DESCRIPTION
To be used by the RTC in uncore and `Configs.scala` in `rocket-chip` (i.e. those forthcoming PRs will depend on this).