### PR TITLE
Fix the Nasti to Smi Converter for single-word Nasti busses

### DIFF
--- a/src/main/scala/smi.scala
+++ b/src/main/scala/smi.scala
@@ -139,7 +139,10 @@ class SmiIONastiReadIOConverter(val dataWidth: Int, val addrWidth: Int)
     }
     nBeats := io.nasti.ar.bits.len
     addr := io.nasti.ar.bits.addr(addrOffBits - 1, byteOffBits)
-    recvInd := io.nasti.ar.bits.addr(wordCountBits + byteOffBits - 1, byteOffBits)
+    if (maxWordsPerBeat > 1)
+      recvInd := io.nasti.ar.bits.addr(wordCountBits + byteOffBits - 1, byteOffBits)
+    else
+      recvInd := UInt(0)
     id := io.nasti.ar.bits.id
     state := s_read
   }


### PR DESCRIPTION
There's a register that tracks what word within a Nasti transaction a
Smi response cooresponds to, since Smi itself doesn't have any
multi-word stuff.  This breaks the single-word Nasti to Smi converter
due to what's essentially a 0-width wire bug: it ends up doing something
like

  word_offset_into_nasti := nasti_address(3, 3)

when "word_offset_into_nasti" should really be a 0-bit register, but due
to some log2Up block size calculation logic it's actually a 1-bit
register.  Thus, this expression ends up grabbing a bit of the address,
which causes odd addresses to get buffered incorrectly.

My fix is to just special-case the "Nasti bus width is the same as Smi
bus width" case.